### PR TITLE
Use OpenSSL lib to generate salt

### DIFF
--- a/lib/hashpasswd.rb
+++ b/lib/hashpasswd.rb
@@ -27,7 +27,7 @@ module Hashpasswd
     @delimeter = options[:delimter] || ':'
     @digest = options[:digest] || 'SHA1'
 
-    salt = SecureRandom.base64(@salt_byte_size)
+    salt = OpenSSL::Random.random_bytes(@salt_byte_size)
     pbkdf2 = OpenSSL::PKCS5::pbkdf2_hmac(
       password,
       salt,


### PR DESCRIPTION
OpenSSL::Random.random_bytes should give the correct number of bytes for salt.

``` bash
irb(main):013:0> salt = OpenSSL::Random.random_bytes(6)
=> "S\xAFJ&\x15\x8D"
```

irb(main):014:0> salt.bytes.to_s
=> "[83, 175, 74, 38, 21, 141]"

fixes #1
